### PR TITLE
LA-4 (Server): Implement Session API's

### DIFF
--- a/server/project/fixtures.json
+++ b/server/project/fixtures.json
@@ -1,15 +1,46 @@
 [
 {
-    "model": "auth.group",
-    "pk": 1,
+    "model": "auth.permission",
     "fields": {
-        "name": "Administrator",
-        "permissions": []
+        "name": "Can add user",
+        "content_type": [
+            "auth",
+            "user"
+        ],
+        "codename": "add_user"
+    }
+},
+{
+    "model": "auth.permission",
+    "fields": {
+        "name": "Can change user",
+        "content_type": [
+            "auth",
+            "user"
+        ],
+        "codename": "change_user"
     }
 },
 {
     "model": "auth.group",
-    "pk": 2,
+    "fields": {
+        "name": "Administrator",
+        "permissions": [
+            [
+                "add_user",
+                "auth",
+                "user"
+            ],
+            [
+                "change_user",
+                "auth",
+                "user"
+            ]
+        ]
+    }
+},
+{
+    "model": "auth.group",
     "fields": {
         "name": "Accountant",
         "permissions": []
@@ -17,7 +48,6 @@
 },
 {
     "model": "auth.group",
-    "pk": 3,
     "fields": {
         "name": "Manager",
         "permissions": []
@@ -25,7 +55,6 @@
 },
 {
     "model": "auth.user",
-    "pk": 1,
     "fields": {
         "password": "pbkdf2_sha256$36000$f8GtYKOOihkH$YMc/eJfk5ZydDQVNzIhCA3rE9cwgl6qCRqO+9o6CQRM=",
         "last_login": null,
@@ -43,7 +72,6 @@
 },
 {
     "model": "auth.user",
-    "pk": 5,
     "fields": {
         "password": "pbkdf2_sha256$36000$xHcyRHFCIMRR$ys3SEsNkvmu/cOKpiUlIFjo7TqlfU/cArYI6M0h3Png=",
         "last_login": null,
@@ -56,14 +84,15 @@
         "is_active": true,
         "date_joined": "2018-02-01T00:00:00Z",
         "groups": [
-            1
+            [
+                "Administrator"
+            ]
         ],
         "user_permissions": []
     }
 },
 {
     "model": "auth.user",
-    "pk": 6,
     "fields": {
         "password": "pbkdf2_sha256$36000$Vx65cYb4YmGi$c9fhOrU0Y1Jdp5COnKzh1G9CQRb7Sgr6eaZu/2FsZaM=",
         "last_login": null,
@@ -76,14 +105,15 @@
         "is_active": true,
         "date_joined": "2018-02-01T00:00:00Z",
         "groups": [
-            2
+            [
+                "Accountant"
+            ]
         ],
         "user_permissions": []
     }
 },
 {
     "model": "auth.user",
-    "pk": 7,
     "fields": {
         "password": "pbkdf2_sha256$36000$De1HBMQxwWmo$RRTBZhpBYYFMvJ6MLJ4QAgwncP8+R4scEYdKhOby9+Y=",
         "last_login": null,
@@ -96,7 +126,9 @@
         "is_active": true,
         "date_joined": "2018-02-01T00:00:00Z",
         "groups": [
-            3
+            [
+                "Manager"
+            ]
         ],
         "user_permissions": []
     }

--- a/server/project/project/permissions.py
+++ b/server/project/project/permissions.py
@@ -1,0 +1,11 @@
+from django.contrib.auth.models import Group
+from rest_framework import permissions
+
+# Custom Django REST Framework permission to check if the current User
+# is in the "Administrator" Group.
+class LAAuthModelReadPermission(permissions.BasePermission):
+    def has_permission(self, request, view):
+        if request.method not in permissions.SAFE_METHODS:
+            return True
+
+        return request.user.is_authenticated and (request.user.is_staff or request.user.groups.filter(name='Administrator').exists())

--- a/server/project/project/serializers.py
+++ b/server/project/project/serializers.py
@@ -1,0 +1,13 @@
+from django.contrib.auth.models import User, Group
+
+from rest_framework import serializers
+
+class UserSerializer(serializers.HyperlinkedModelSerializer):
+    class Meta:
+        model = User
+        fields = ('first_name', 'last_name', 'groups', 'last_login', 'is_active')
+
+class GroupSerializer(serializers.HyperlinkedModelSerializer):
+    class Meta:
+        model = Group
+        fields = ('name',)

--- a/server/project/project/settings.py
+++ b/server/project/project/settings.py
@@ -37,6 +37,8 @@ INSTALLED_APPS = [
     'django.contrib.sessions',
     'django.contrib.messages',
     'django.contrib.staticfiles',
+
+    'rest_framework'
 ]
 
 MIDDLEWARE = [
@@ -120,3 +122,12 @@ USE_TZ = True
 
 STATIC_URL = '/static/backend/'
 STATIC_ROOT = os.path.join(BASE_DIR, 'static')
+
+# REST Framework
+# http://www.django-rest-framework.org/
+
+REST_FRAMEWORK = {
+    'DEFAULT_PERMISSION_CLASSES': [
+        'rest_framework.permissions.IsAuthenticated'
+    ]
+}

--- a/server/project/project/urls.py
+++ b/server/project/project/urls.py
@@ -13,9 +13,25 @@ Including another URLconf
     1. Import the include() function: from django.conf.urls import url, include
     2. Add a URL to urlpatterns:  url(r'^blog/', include('blog.urls'))
 """
-from django.conf.urls import url
+from django.conf.urls import url, include
 from django.contrib import admin
+
+from rest_framework import routers
+
+from . import views
+
+router = routers.DefaultRouter()
+
+router.register(r'users', views.UserViewSet)
+router.register(r'groups', views.GroupViewSet)
 
 urlpatterns = [
     url(r'^admin/', admin.site.urls),
+    url(r'^api/', include(router.urls)),
+    url(r'^auth/', include([
+        url(r'^login/', views.login_view),
+        url(r'^logout/', views.logout_view),
+        url(r'^current/', views.current_view)
+    ])),
+    url(r'^auth2/', include('rest_framework.urls', namespace='rest_framework'))
 ]

--- a/server/project/project/views.py
+++ b/server/project/project/views.py
@@ -1,0 +1,42 @@
+from django.contrib.auth import authenticate, login, logout
+from django.contrib.auth.models import User, Group
+from rest_framework import viewsets, status
+from rest_framework.decorators import api_view, parser_classes, permission_classes
+from rest_framework.response import Response
+from rest_framework.parsers import JSONParser
+from rest_framework.permissions import AllowAny
+
+from .serializers import UserSerializer, GroupSerializer
+
+@api_view(['POST'])
+@permission_classes((AllowAny,))
+@parser_classes((JSONParser,))
+def login_view(request):
+    username = request.data['username']
+    password = request.data['password']
+
+    user = authenticate(request._request, username=username, password=password)
+
+    if user is None:
+        return Response(status=status.HTTP_401_UNAUTHORIZED)
+
+    login(request._request, user)
+    return Response(UserSerializer(user, context={ 'request': request }).data)
+
+@api_view(['POST'])
+def logout_view(request):
+    logout(request._request)
+    return Response(status=status.HTTP_200_OK)
+
+@api_view(['GET'])
+def current_view(request):
+    return Response(UserSerializer(request.user, context={ 'request': request }).data)
+
+
+class UserViewSet(viewsets.ModelViewSet):
+    queryset = User.objects.all()
+    serializer_class = UserSerializer
+
+class GroupViewSet(viewsets.ModelViewSet):
+    queryset = Group.objects.all()
+    serializer_class = GroupSerializer

--- a/server/project/project/views.py
+++ b/server/project/project/views.py
@@ -4,8 +4,9 @@ from rest_framework import viewsets, status
 from rest_framework.decorators import api_view, parser_classes, permission_classes
 from rest_framework.response import Response
 from rest_framework.parsers import JSONParser
-from rest_framework.permissions import AllowAny
+from rest_framework.permissions import AllowAny, DjangoModelPermissions
 
+from .permissions import LAAuthModelReadPermission
 from .serializers import UserSerializer, GroupSerializer
 
 @api_view(['POST'])
@@ -36,7 +37,9 @@ def current_view(request):
 class UserViewSet(viewsets.ModelViewSet):
     queryset = User.objects.all()
     serializer_class = UserSerializer
+    permission_classes = (DjangoModelPermissions, LAAuthModelReadPermission,)
 
 class GroupViewSet(viewsets.ModelViewSet):
     queryset = Group.objects.all()
     serializer_class = GroupSerializer
+    permission_classes = (DjangoModelPermissions, LAAuthModelReadPermission,)

--- a/server/provision/roles/apache-server/files/virtualhost.conf
+++ b/server/provision/roles/apache-server/files/virtualhost.conf
@@ -4,6 +4,8 @@
     WSGIDaemonProcess project user=vagrant python-home=/home/vagrant/project_env python-path=/vagrant/server/project
     WSGIProcessGroup project
     WSGIScriptAlias /api /vagrant/server/project/project/wsgi.py/api
+    WSGIScriptAlias /auth /vagrant/server/project/project/wsgi.py/auth
+    WSGIScriptAlias /auth2 /vagrant/server/project/project/wsgi.py/auth2
     WSGIScriptAlias /admin /vagrant/server/project/project/wsgi.py/admin
 
     <Directory /vagrant/server/project/project>
@@ -14,7 +16,7 @@
 
     Alias /static/backend /vagrant/server/project/static
     Alias /static/frontend /vagrant/client/build
-    AliasMatch ^/$ /vagrant/client/build/index.html
+    AliasMatch ^\/(?!api|auth|auth2|admin).*$ /vagrant/client/build/index.html
 
     <Directory /vagrant/server/project/static>
         Require all granted


### PR DESCRIPTION
Addresses issue #4 .

Also makes the following changes:
  * Enable the Django REST Framework (DRF) browsable API (visit `localhost:8079/api` in a web browser)
  * Add endpoints for User and Group models
  * Guards all endpoints except login with a basic authentication check by default
  * Guard User and Group API endpoints with group-based CRUD permission checks e.g.
    - Only Administrators/Super User can read, add, or modify on Users API. Only Super User can delete.
    - Only Administrator/Super User can read on Groups API. Only Super User can add, modify, or delete.
  * Fix Apache VirtualHost redirection for client side routing

Remember to run `vagrant provision` before testing the branch.

@Appleman8977 
While you are free to implement API's for this project as you wish (as long as they work and are permissions guarded), I would highly recommend looking at the change set on this PR as it might help to convey the utility and simplicity of DRF in a way that the official documentation does not. I would recommend looking at the three commits in isolation for ease of review.

Also I would like for you to check out the browsable API. Just visit `localhost:8079/api` from a web browser and log in as one of the users defined in the fixture data. You'll see that you can literally "browse" the API, looking at data responses, and even test the API endpoints by doing HTTP requests directly to the API using the auto-generated HTML forms. This is all stuff that is given essentially for free when you use Django REST Framework ViewSet's and APIView's, and it is very cool.